### PR TITLE
Added case where an area reports None in its unmatched loads in d3a. …

### DIFF
--- a/d3a_interface/sim_results/aggregate_results.py
+++ b/d3a_interface/sim_results/aggregate_results.py
@@ -35,6 +35,9 @@ class UnmatchedLoadsHelpers:
         :param area: area of the accumulated unmatched loads
         :return: None
         """
+        if area not in current_results or current_results[area] is None:
+            accumulated_results[area] = None
+            return
         for target, target_value in current_results[area].items():
             if target not in accumulated_results[area]:
                 accumulated_results[area][target] = deepcopy(target_value)


### PR DESCRIPTION
…That way the interface will accept the None value and not stop the parsing of the results.

Should deal with https://sentry.io/organizations/grid-singularity/issues/1476720597/?project=1199609&query=is%3Aunresolved this sentry issue.  