### PR TITLE
Feature/d3asim 3307 Created an interface for the results classes. Added a manager class for all the simulation result objects. 

### DIFF
--- a/d3a_interface/sim_results/__init__.py
+++ b/d3a_interface/sim_results/__init__.py
@@ -77,3 +77,7 @@ def child_buys_from_area(trade, area_name, child_names):
 
 def area_name_from_area_or_iaa_name(name):
     return name[4:] if name[:4] == 'IAA ' else name
+
+
+RESULT_NAMES_LIST = ["unmatched_loads", "price_energy_day", "cumulative_grid_trades", "bills", "cumulative_bills",
+                     "device_statistics", "energy_trade_profile", "kpi", "area_throughput"]

--- a/d3a_interface/sim_results/__init__.py
+++ b/d3a_interface/sim_results/__init__.py
@@ -77,7 +77,3 @@ def child_buys_from_area(trade, area_name, child_names):
 
 def area_name_from_area_or_iaa_name(name):
     return name[4:] if name[:4] == 'IAA ' else name
-
-
-RESULT_NAMES_LIST = ["unmatched_loads", "price_energy_day", "cumulative_grid_trades", "bills", "cumulative_bills",
-                     "device_statistics", "energy_trade_profile", "kpi", "area_throughput"]

--- a/d3a_interface/sim_results/aggregate_results.py
+++ b/d3a_interface/sim_results/aggregate_results.py
@@ -15,203 +15,44 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
-from copy import deepcopy
 from datetime import timedelta, date  # NOQA
 from typing import Dict, List
 from d3a_interface.utils import generate_market_slot_list_from_config, \
     convert_datetime_to_str_in_list
+from d3a_interface.sim_results.area_throughput_stats import AreaThroughputStats
+from d3a_interface.sim_results.energy_trade_profile import EnergyTradeProfile
+from d3a_interface.sim_results.market_price_energy_day import MarketPriceEnergyDay
+from d3a_interface.sim_results.export_unmatched_loads import MarketUnmatchedLoads
+from d3a_interface.sim_results.device_statistics import DeviceStatistics
 
 
-class UnmatchedLoadsHelpers:
+REQUESTED_FIELDS_LIST = ["unmatched_loads", "price_energy_day", "device_statistics",
+                         "energy_trade_profile", "area_throughput"]
 
-    @classmethod
-    def _merge_base_area_unmatched_loads(cls, accumulated_results: Dict,
-                                         current_results: Dict, area: str):
-        """
-        Recurses over all children (target areas) of base area and calculates the unmatched
-        loads for each
-        :param accumulated_results: stores the merged unmatched load results, changes by reference
-        :param current_results: results for the current market, that are used to update the
-        accumulated results
-        :param area: area of the accumulated unmatched loads
-        :return: None
-        """
-        if area not in current_results or current_results[area] is None:
-            accumulated_results[area] = None
-            return
-        for target, target_value in current_results[area].items():
-            if target not in accumulated_results[area]:
-                accumulated_results[area][target] = deepcopy(target_value)
-            else:
-                if target == 'type':
-                    continue
-                elif target == 'unmatched_loads':
-                    cls._copy_accumulated_unmatched_loads(
-                        accumulated_results, current_results, area
-                    )
-                else:
-                    cls._merge_target_area_unmatched_loads(
-                        accumulated_results, current_results, area, target
-                    )
-
-    @classmethod
-    def _merge_target_area_unmatched_loads(cls, accumulated_results: Dict,
-                                           current_results: Dict, area: str, target: str):
-        """
-        Merges the unmatched loads and unmatched times for a base area and a target area.
-        :param accumulated_results: stores the merged unmatched load results, changes by reference
-        :param current_results: results for the current market, that are used to update the
-        accumulated results
-        :param area: area of the accumulated unmatched loads
-        :param target: target area of the accumulated unmatched loads
-        :return: None
-        """
-        target_ul = accumulated_results[area][target]['unmatched_loads']
-        current_ul = current_results[area][target]['unmatched_loads']
-        for timestamp, ts_value in current_ul.items():
-            if timestamp not in target_ul:
-                target_ul[timestamp] = deepcopy(ts_value)
-            else:
-                if 'unmatched_times' not in current_ul[timestamp]:
-                    continue
-                if 'unmatched_times' not in target_ul[timestamp]:
-                    target_ul[timestamp]['unmatched_times'] = {}
-                for device, time_list in current_ul[timestamp]['unmatched_times'].items():
-                    if device not in target_ul[timestamp]['unmatched_times']:
-                        target_ul[timestamp]['unmatched_times'][device] = deepcopy(time_list)
-                    else:
-                        for ts in time_list:
-                            if ts not in target_ul[timestamp]['unmatched_times'][device]:
-                                target_ul[timestamp]['unmatched_times'][device].append(ts)
-
-                unm_count = 0
-                for _, hours in target_ul[timestamp]['unmatched_times'].items():
-                    unm_count += len(hours)
-
-                    target_ul[timestamp]['unmatched_count'] = unm_count
-
-    @classmethod
-    def _copy_accumulated_unmatched_loads(cls, accumulated_results: Dict,
-                                          current_results: Dict, area: str):
-        """
-        Copies the accumulated results from the market results to the incremental results
-        :param accumulated_results: stores the merged unmatched load results, changes by reference
-        :param current_results: results for the current market, that are used to update the
-        accumulated results
-        :param area: area of the accumulated unmatched loads
-        :return: None
-        """
-        for timestamp, ts_value in current_results[area]['unmatched_loads'].items():
-            if timestamp not in accumulated_results[area]['unmatched_loads']:
-                accumulated_results[area]['unmatched_loads'][timestamp] = deepcopy(ts_value)
-
-    @classmethod
-    def accumulate_current_market_results(cls, accumulated_results: Dict, current_results: Dict):
-        """
-        Method which starts the merging of the current market unmatched loads with the
-        existing unmatched loads (_unmatched_loads_incremental)
-        :param accumulated_results: return value, stores the merged unmatched load results
-        :param current_results: results for the current market, that are used to update the
-        accumulated results
-        :return: accumulated_results
-        """
-        for base_area, target_results in current_results.items():
-            if base_area not in accumulated_results:
-                accumulated_results[base_area] = deepcopy(target_results)
-            else:
-                cls._merge_base_area_unmatched_loads(
-                    accumulated_results, current_results, base_area
-                )
-        return accumulated_results
-
-
-def merge_unmatched_load_results_to_global(market_ul: Dict, global_ul: Dict):
-    if not global_ul:
-        global_ul = market_ul
-        return global_ul
-    return UnmatchedLoadsHelpers.accumulate_current_market_results(global_ul, market_ul)
-
-
-def merge_price_energy_day_results_to_global(market_pe: Dict, global_pe: Dict):
-    if not global_pe:
-        global_pe = market_pe
-        return global_pe
-    for area_uuid in market_pe:
-        if area_uuid not in global_pe:
-            global_pe[area_uuid] = deepcopy(market_pe[area_uuid])
-        else:
-            global_pe[area_uuid]["price-energy-day"].extend(
-                market_pe[area_uuid]["price-energy-day"])
-    return global_pe
-
-
-def merge_device_statistics_results_to_global(market_device: Dict, global_device: Dict):
-    if not global_device:
-        global_device = market_device
-        return global_device
-    for area_uuid in market_device:
-        if area_uuid not in global_device:
-            global_device[area_uuid] = market_device[area_uuid]
-        else:
-            for stat in market_device[area_uuid]:
-                if stat not in global_device[area_uuid]:
-                    global_device[area_uuid][stat] = market_device[area_uuid][stat]
-                else:
-                    global_device[area_uuid][stat].update(market_device[area_uuid][stat])
-    return global_device
-
-
-def merge_energy_trade_profile_to_global(market_trade: Dict, global_trade: Dict, slot_list: List):
-    if not global_trade:
-        global_trade = market_trade
-        return global_trade
-    for area_uuid in market_trade:
-        if area_uuid not in global_trade or global_trade[area_uuid] == {}:
-            global_trade[area_uuid] = {"sold_energy": {}, "bought_energy": {}}
-        for sold_bought in market_trade[area_uuid]:
-            for target_area in market_trade[area_uuid][sold_bought]:
-                if target_area not in global_trade[area_uuid][sold_bought]:
-                    global_trade[area_uuid][sold_bought][target_area] = {}
-                for source_area in market_trade[area_uuid][sold_bought][target_area]:
-                    if source_area not in global_trade[area_uuid][sold_bought][target_area]:
-                        global_trade[area_uuid][sold_bought][target_area][source_area] = \
-                            {i: 0 for i in slot_list}
-                    global_trade[area_uuid][sold_bought][target_area][source_area].update(
-                        market_trade[area_uuid][sold_bought][target_area][source_area]
-                    )
-    return global_trade
-
-
-def merge_area_throughput_results_to_global(market_trade: Dict, global_trade: Dict):
-    if not global_trade:
-        global_trade = market_trade
-        return global_trade
-    for area_uuid in market_trade:
-        if area_uuid not in global_trade or global_trade[area_uuid] == {}:
-            global_trade[area_uuid] = {}
-        for time_slot in market_trade[area_uuid]:
-            global_trade[area_uuid][time_slot] = market_trade[area_uuid][time_slot]
-    return global_trade
+REQUESTED_FIELDS_CLASS_MAP = {
+    "unmatched_loads": MarketUnmatchedLoads,
+    "price_energy_day": MarketPriceEnergyDay,
+    "device_statistics": DeviceStatistics,
+    "energy_trade_profile": EnergyTradeProfile,
+    "area_throughput": AreaThroughputStats
+}
 
 
 def merge_last_market_results_to_global(
         market_results: Dict, global_results: Dict,
-        sim_duration: timedelta, start_date: date, market_count: int, slot_length: timedelta
+        sim_duration: timedelta, start_date: date, market_count: int, slot_length: timedelta,
+        requested_fields: List = None
 ):
+    if requested_fields is None:
+        requested_fields = REQUESTED_FIELDS_LIST
+
     slot_list_ui_format = convert_datetime_to_str_in_list(
         generate_market_slot_list_from_config(sim_duration, start_date, market_count, slot_length),
         ui_format=True)
-    global_results["unmatched_loads"] = merge_unmatched_load_results_to_global(
-        market_results["unmatched_loads"], global_results["unmatched_loads"])
-    global_results["price_energy_day"] = merge_price_energy_day_results_to_global(
-        market_results["price_energy_day"], global_results["price_energy_day"])
-    global_results["device_statistics"] = merge_device_statistics_results_to_global(
-        market_results["device_statistics"], global_results["device_statistics"])
-    global_results["energy_trade_profile"] = merge_energy_trade_profile_to_global(
-        market_results["energy_trade_profile"],
-        global_results["energy_trade_profile"], slot_list_ui_format
-    )
-    global_results["area_throughput"] = merge_area_throughput_results_to_global(
-        market_results["area_throughput"], global_results["area_throughput"]
-    )
+
+    for field in requested_fields:
+        global_results[field] = REQUESTED_FIELDS_CLASS_MAP[field].merge_results_to_global(
+            market_results[field], global_results[field], slot_list_ui_format
+        )
+
     return global_results

--- a/d3a_interface/sim_results/all_results.py
+++ b/d3a_interface/sim_results/all_results.py
@@ -6,6 +6,7 @@ from d3a_interface.sim_results.device_statistics import DeviceStatistics
 from d3a_interface.sim_results.export_unmatched_loads import MarketUnmatchedLoads
 from d3a_interface.sim_results.energy_trade_profile import EnergyTradeProfile
 from d3a_interface.sim_results.cumulative_grid_trades import CumulativeGridTrades
+from d3a_interface.sim_results.cumulative_net_energy_flow import CumulativeNetEnergyFlow
 from d3a_interface.sim_results.kpi import KPI
 
 
@@ -16,6 +17,7 @@ class ResultsHandler:
         self.results_mapping = {
             "bills": MarketEnergyBills(should_export_plots),
             "kpi": KPI(),
+            "cumulative_net_energy_flow": CumulativeNetEnergyFlow(),
             "unmatched_loads": MarketUnmatchedLoads(),
             "price_energy_day": MarketPriceEnergyDay(should_export_plots),
             "cumulative_bills": CumulativeBills(),

--- a/d3a_interface/sim_results/all_results.py
+++ b/d3a_interface/sim_results/all_results.py
@@ -47,3 +47,7 @@ class ResultsHandler:
             k: v.ui_formatted_results
             for k, v in self.results_mapping.items()
         }
+
+    @property
+    def trade_profile_plot_results(self):
+        return self.results_mapping["trade_profile"].plot_results

--- a/d3a_interface/sim_results/all_results.py
+++ b/d3a_interface/sim_results/all_results.py
@@ -1,0 +1,49 @@
+from typing import Dict
+from d3a_interface.sim_results.market_price_energy_day import MarketPriceEnergyDay
+from d3a_interface.sim_results.area_throughput_stats import AreaThroughputStats
+from d3a_interface.sim_results.bills import MarketEnergyBills, CumulativeBills
+from d3a_interface.sim_results.device_statistics import DeviceStatistics
+from d3a_interface.sim_results.export_unmatched_loads import MarketUnmatchedLoads
+from d3a_interface.sim_results.energy_trade_profile import EnergyTradeProfile
+from d3a_interface.sim_results.cumulative_grid_trades import CumulativeGridTrades
+from d3a_interface.sim_results.kpi import KPI
+
+
+class ResultsHandler:
+    def __init__(self, should_export_plots: bool = True):
+        self.should_export_plots = should_export_plots
+        if self.should_export_plots:
+            self.results_mapping = {
+                "bills": MarketEnergyBills(should_export_plots),
+                "kpi": KPI(),
+                "unmatched_loads": MarketUnmatchedLoads(),
+                "price_energy_day": MarketPriceEnergyDay(should_export_plots),
+                "cumulative_bills": CumulativeBills(),
+                "cumulative_grid_trades": CumulativeGridTrades(),
+                "device_statistics": DeviceStatistics(should_export_plots),
+                "trade_profile": EnergyTradeProfile(should_export_plots),
+                "area_throughput_stats": AreaThroughputStats(),
+            }
+        else:
+            self.results_mapping = {
+                "bills": MarketEnergyBills(should_export_plots),
+                "kpi": KPI()
+            }
+
+    def update(self, area_dict: Dict, core_stats: Dict, current_market_slot: str):
+        for _, v in self.results_mapping.items():
+            v.update(area_dict, core_stats, current_market_slot)
+
+    @property
+    def all_raw_results(self) -> Dict:
+        return {
+            k: v.raw_results
+            for k, v in self.results_mapping.items()
+        }
+
+    @property
+    def all_ui_results(self) -> Dict:
+        return {
+            k: v.ui_formatted_results
+            for k, v in self.results_mapping.items()
+        }

--- a/d3a_interface/sim_results/area_throughput_stats.py
+++ b/d3a_interface/sim_results/area_throughput_stats.py
@@ -28,7 +28,7 @@ class AreaThroughputStats(ResultsBaseClass):
         self.imported_energy = {}
 
     def update(self, area_result_dict=None, core_stats=None, current_market_slot=None):
-        if not self._validate_update_parameters(
+        if not self._has_update_parameters(
                 area_result_dict, core_stats, current_market_slot):
             return
         self.results = {}

--- a/d3a_interface/sim_results/area_throughput_stats.py
+++ b/d3a_interface/sim_results/area_throughput_stats.py
@@ -15,22 +15,25 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
+from typing import Dict
 from d3a_interface.utils import round_floats_for_ui, create_subdict_or_update
+from d3a_interface.sim_results.results_abc import ResultsBaseClass
 
 
-class AreaThroughputStats:
+class AreaThroughputStats(ResultsBaseClass):
     def __init__(self):
         self.results = {}
         self.results_redis = {}
         self.exported_energy = {}
         self.imported_energy = {}
 
-    def update(self, area_dict, core_stats, current_market_time_slot_str):
-        if current_market_time_slot_str == "":
+    def update(self, area_result_dict=None, core_stats=None, current_market_slot=None):
+        if not self._validate_update_parameters(
+                area_result_dict, core_stats, current_market_slot):
             return
         self.results = {}
         self.results_redis = {}
-        self.update_results(area_dict, core_stats, current_market_time_slot_str)
+        self.update_results(area_result_dict, core_stats, current_market_slot)
 
     def update_results(self, area_dict, core_stats, current_market_time_slot_str):
         area_throughput = core_stats.get(area_dict['uuid'], {}).get('area_throughput', {})
@@ -87,3 +90,15 @@ class AreaThroughputStats:
         for child in area_dict['children']:
             if child['type'] == "Area":
                 self.update_results(child, core_stats, current_market_time_slot_str)
+
+    @staticmethod
+    def merge_results_to_global(market_trade: Dict, global_trade: Dict, _):
+        if not global_trade:
+            global_trade = market_trade
+            return global_trade
+        for area_uuid in market_trade:
+            if area_uuid not in global_trade or global_trade[area_uuid] == {}:
+                global_trade[area_uuid] = {}
+            for time_slot in market_trade[area_uuid]:
+                global_trade[area_uuid][time_slot] = market_trade[area_uuid][time_slot]
+        return global_trade

--- a/d3a_interface/sim_results/area_throughput_stats.py
+++ b/d3a_interface/sim_results/area_throughput_stats.py
@@ -92,7 +92,7 @@ class AreaThroughputStats(ResultsBaseClass):
                 self.update_results(child, core_stats, current_market_time_slot_str)
 
     @staticmethod
-    def merge_results_to_global(market_trade: Dict, global_trade: Dict, _):
+    def merge_results_to_global(market_trade: Dict, global_trade: Dict, *_):
         if not global_trade:
             global_trade = market_trade
             return global_trade

--- a/d3a_interface/sim_results/area_throughput_stats.py
+++ b/d3a_interface/sim_results/area_throughput_stats.py
@@ -102,3 +102,14 @@ class AreaThroughputStats(ResultsBaseClass):
             for time_slot in market_trade[area_uuid]:
                 global_trade[area_uuid][time_slot] = market_trade[area_uuid][time_slot]
         return global_trade
+
+    def restore_area_results_state(self, area_uuid, last_known_state_data):
+        pass
+
+    @property
+    def raw_results(self):
+        return self.results
+
+    @property
+    def ui_formatted_results(self):
+        return self.results_redis

--- a/d3a_interface/sim_results/bills.py
+++ b/d3a_interface/sim_results/bills.py
@@ -67,7 +67,7 @@ class CumulativeBills(ResultsBaseClass):
             }
 
     def update(self, area_dict=None, core_stats=None, current_market_slot=None):
-        if not self._validate_update_parameters(
+        if not self._has_update_parameters(
                 area_dict, core_stats, current_market_slot):
             return
         for child in area_dict['children']:
@@ -266,7 +266,7 @@ class MarketEnergyBills(ResultsBaseClass):
         self._accumulate_market_fees(area_dict, area_core_stats)
 
     def update(self, area_dict, area_core_stats, current_market_slot):
-        if not self._validate_update_parameters(
+        if not self._has_update_parameters(
                 area_dict, area_core_stats, current_market_slot):
             return
         # Updates the self.market_fees dict which keeps track of the accumulated market fees for

--- a/d3a_interface/sim_results/bills.py
+++ b/d3a_interface/sim_results/bills.py
@@ -16,14 +16,16 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 from copy import deepcopy, copy
+from typing import Dict
 from d3a_interface.utils import round_floats_for_ui, get_area_uuid_name_mapping, \
     key_in_dict_and_not_none
 from d3a_interface.sim_results import is_load_node_type, is_pv_node_type, \
     area_name_from_area_or_iaa_name, get_unified_area_type
 from d3a_interface.constants_limits import ConstSettings
+from d3a_interface.sim_results.results_abc import ResultsBaseClass
 
 
-class CumulativeBills:
+class CumulativeBills(ResultsBaseClass):
     def __init__(self):
         self.cumulative_bills_results = {}
 
@@ -64,9 +66,12 @@ class CumulativeBills:
                 "total": last_known_state_data['total'],
             }
 
-    def update_cumulative_bills(self, area_dict, core_stats, current_market_time_slot):
+    def update(self, area_dict=None, core_stats=None, current_market_slot=None):
+        if not self._validate_update_parameters(
+                area_dict, core_stats, current_market_slot):
+            return
         for child in area_dict['children']:
-            self.update_cumulative_bills(child, core_stats, current_market_time_slot)
+            self.update(child, core_stats, current_market_slot)
 
         if area_dict['uuid'] not in self.cumulative_bills_results:
             self.cumulative_bills_results[area_dict['uuid']] = {
@@ -121,15 +126,24 @@ class CumulativeBills:
             self.cumulative_bills_results[area_dict['uuid']]["penalty_energy"] += penalty_energy
             self.cumulative_bills_results[area_dict['uuid']]["total"] += total
 
+    @staticmethod
+    def merge_results_to_global(market_device: Dict, global_device: Dict, *_):
+        raise NotImplemented("Cumulative bills endpoint supports only global results, "
+                             "merge not supported.")
 
-class MarketEnergyBills:
+    @property
+    def raw_results(self):
+        return self.cumulative_bills
+
+
+class MarketEnergyBills(ResultsBaseClass):
     def __init__(self, should_export_plots=False):
         self._should_export_plots = should_export_plots
         self.current_raw_bills = {}
         self.bills_results = {}
         self.bills_redis_results = {}
         self.market_fees = {}
-        self.cumulative_fee_all_markets_whole_sim = 0.
+        self._cumulative_fee_all_markets_whole_sim = 0.
         self.external_trades = {}
 
     @staticmethod
@@ -243,14 +257,17 @@ class MarketEnergyBills:
             self.market_fees[area_dict['uuid']] = 0.0
         market_fee_eur = area_core_stats[area_dict['uuid']]['market_fee'] / 100.0
         self.market_fees[area_dict['uuid']] += market_fee_eur
-        self.cumulative_fee_all_markets_whole_sim += market_fee_eur
+        self._cumulative_fee_all_markets_whole_sim += market_fee_eur
         for child in area_dict['children']:
             self._accumulate_market_fees(child, area_core_stats)
 
     def _update_market_fees(self, area_dict, area_core_stats):
         self._accumulate_market_fees(area_dict, area_core_stats)
 
-    def update(self, area_dict, area_core_stats):
+    def update(self, area_dict, area_core_stats, current_market_slot):
+        if not self._validate_update_parameters(
+                area_dict, area_core_stats, current_market_slot):
+            return
         # Updates the self.market_fees dict which keeps track of the accumulated market fees for
         # each area. Also calculates the cumulative_fee_all_markets_whole_sim, which
         # is the sum of the grid fees for all markets for the whole simulation duration.
@@ -466,3 +483,19 @@ class MarketEnergyBills:
                     for c_name, child_results in area_results.items()
                 }
         return rounded_results
+
+    @staticmethod
+    def merge_results_to_global(market_device: Dict, global_device: Dict, *_):
+        raise NotImplemented("Bills endpoint supports only global results, merge not supported.")
+
+    @property
+    def raw_results(self):
+        return self.bills_results
+
+    @property
+    def ui_formatted_results(self):
+        return self.bills_redis_results
+
+    @property
+    def cumulative_fee_all_markets_whole_sim(self):
+        return self._cumulative_fee_all_markets_whole_sim

--- a/d3a_interface/sim_results/bills.py
+++ b/d3a_interface/sim_results/bills.py
@@ -128,8 +128,9 @@ class CumulativeBills(ResultsBaseClass):
 
     @staticmethod
     def merge_results_to_global(market_device: Dict, global_device: Dict, *_):
-        raise NotImplemented("Cumulative bills endpoint supports only global results, "
-                             "merge not supported.")
+        raise NotImplementedError(
+            "Cumulative bills endpoint supports only global results, "
+            "merge not supported.")
 
     @property
     def raw_results(self):
@@ -489,7 +490,8 @@ class MarketEnergyBills(ResultsBaseClass):
 
     @staticmethod
     def merge_results_to_global(market_device: Dict, global_device: Dict, *_):
-        raise NotImplemented("Bills endpoint supports only global results, merge not supported.")
+        raise NotImplementedError(
+            "Bills endpoint supports only global results, merge not supported.")
 
     @property
     def raw_results(self):

--- a/d3a_interface/sim_results/bills.py
+++ b/d3a_interface/sim_results/bills.py
@@ -322,6 +322,9 @@ class MarketEnergyBills(ResultsBaseClass):
                 self.external_trades[area_dict['uuid']]['earned'] + \
                 self.external_trades[area_dict['uuid']]['market_fee']
 
+    def restore_cumulative_fees_whole_sim(self, cumulative_fees):
+        self._cumulative_fee_all_markets_whole_sim = cumulative_fees
+
     @classmethod
     def _flatten_energy_bills(cls, energy_bills, flat_results):
         for k, v in energy_bills.items():

--- a/d3a_interface/sim_results/cumulative_grid_trades.py
+++ b/d3a_interface/sim_results/cumulative_grid_trades.py
@@ -34,9 +34,12 @@ class CumulativeGridTrades(ResultsBaseClass):
         self.accumulated_balancing_trades = {}
         self._restored = False
 
-    def update(self, area_dict, flattened_area_core_stats_dict, *_):
+    def update(self, area_dict, core_stats, current_market_slot):
+        if not self._has_update_parameters(
+                area_dict, core_stats, current_market_slot):
+            return
         self.export_cumulative_grid_trades(
-            area_dict, flattened_area_core_stats_dict, self.accumulated_trades
+            area_dict, core_stats, self.accumulated_trades
         )
         self._restored = False
 

--- a/d3a_interface/sim_results/cumulative_grid_trades.py
+++ b/d3a_interface/sim_results/cumulative_grid_trades.py
@@ -397,8 +397,9 @@ class CumulativeGridTrades(ResultsBaseClass):
 
     @staticmethod
     def merge_results_to_global(market_device: Dict, global_device: Dict, *_):
-        raise NotImplemented("Cumulative grid trades endpoint supports only global results,"
-                             " merge not supported.")
+        raise NotImplementedError(
+            "Cumulative grid trades endpoint supports only global results,"
+            " merge not supported.")
 
     @property
     def raw_results(self):

--- a/d3a_interface/sim_results/cumulative_grid_trades.py
+++ b/d3a_interface/sim_results/cumulative_grid_trades.py
@@ -16,16 +16,17 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 import ast
-
+from typing import Dict
 from d3a_interface.constants_limits import FLOATING_POINT_TOLERANCE
 from d3a_interface.sim_results import is_load_node_type, \
     is_producer_node_type, is_prosumer_node_type, is_buffer_node_type, area_sells_to_child, \
     child_buys_from_area, area_name_from_area_or_iaa_name
 from d3a_interface.utils import add_or_create_key, \
     make_iaa_name_from_dict, subtract_or_create_key, round_floats_for_ui
+from d3a_interface.sim_results.results_abc import ResultsBaseClass
 
 
-class CumulativeGridTrades:
+class CumulativeGridTrades(ResultsBaseClass):
     def __init__(self):
         self.current_trades = {}
         self.current_balancing_trades = {}
@@ -33,7 +34,7 @@ class CumulativeGridTrades:
         self.accumulated_balancing_trades = {}
         self._restored = False
 
-    def update(self, area_dict, flattened_area_core_stats_dict):
+    def update(self, area_dict, flattened_area_core_stats_dict, *_):
         self.export_cumulative_grid_trades(
             area_dict, flattened_area_core_stats_dict, self.accumulated_trades
         )
@@ -393,3 +394,12 @@ class CumulativeGridTrades:
             results[area_uuid].append(CumulativeGridTrades._external_trade_entries(
                 area_uuid, accumulated_trades))
         return results
+
+    @staticmethod
+    def merge_results_to_global(market_device: Dict, global_device: Dict, *_):
+        raise NotImplemented("Cumulative grid trades endpoint supports only global results,"
+                             " merge not supported.")
+
+    @property
+    def raw_results(self):
+        return self.accumulated_trades

--- a/d3a_interface/sim_results/device_statistics.py
+++ b/d3a_interface/sim_results/device_statistics.py
@@ -240,7 +240,7 @@ class DeviceStatistics(ResultsBaseClass):
         flat_result_dict[area_dict["uuid"]] = subdict.copy()
 
     @staticmethod
-    def merge_results_to_global(market_device: Dict, global_device: Dict, _):
+    def merge_results_to_global(market_device: Dict, global_device: Dict, *_):
         if not global_device:
             global_device = market_device
             return global_device

--- a/d3a_interface/sim_results/device_statistics.py
+++ b/d3a_interface/sim_results/device_statistics.py
@@ -254,3 +254,14 @@ class DeviceStatistics(ResultsBaseClass):
                     else:
                         global_device[area_uuid][stat].update(market_device[area_uuid][stat])
         return global_device
+
+    def restore_area_results_state(self, area_uuid, last_known_state_data):
+        pass
+
+    @property
+    def raw_results(self):
+        return self.device_stats_dict
+
+    @property
+    def ui_formatted_results(self):
+        return self.current_stats_dict

--- a/d3a_interface/sim_results/device_statistics.py
+++ b/d3a_interface/sim_results/device_statistics.py
@@ -180,7 +180,7 @@ class DeviceStatistics(ResultsBaseClass):
         cls._calc_min_max_from_sim_dict(subdict, key_name)
 
     def update(self, area_result_dict=None, core_stats=None, current_market_slot=None):
-        if not self._validate_update_parameters(
+        if not self._has_update_parameters(
                 area_result_dict, core_stats, current_market_slot):
             return
         if self.should_export_plots:

--- a/d3a_interface/sim_results/energy_trade_profile.py
+++ b/d3a_interface/sim_results/energy_trade_profile.py
@@ -175,6 +175,10 @@ class EnergyTradeProfile(ResultsBaseClass):
         pass
 
     @property
+    def plot_results(self):
+        return self.convert_timestamp_strings_to_datetimes(self.traded_energy_profile)
+
+    @property
     def raw_results(self):
         return convert_pendulum_to_str_in_dict(
             self.traded_energy_profile, {}, ui_format=True)

--- a/d3a_interface/sim_results/energy_trade_profile.py
+++ b/d3a_interface/sim_results/energy_trade_profile.py
@@ -18,7 +18,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 from typing import Dict, List
 from d3a_interface.constants_limits import FLOATING_POINT_TOLERANCE
 from d3a_interface.utils import round_floats_for_ui, add_or_create_key, key_in_dict_and_not_none, \
-    ui_str_to_pendulum_datetime, convert_pendulum_to_str_in_dict
+    ui_str_to_pendulum_datetime, convert_pendulum_to_str_in_dict, \
+    datetime_str_to_ui_formatted_datetime_str
 from d3a_interface.sim_results import area_name_from_area_or_iaa_name
 from d3a_interface.sim_results.results_abc import ResultsBaseClass
 
@@ -33,6 +34,7 @@ class EnergyTradeProfile(ResultsBaseClass):
         if not self._validate_update_parameters(
                 area_result_dict, core_stats, current_market_slot):
             return
+        current_market_slot = datetime_str_to_ui_formatted_datetime_str(current_market_slot)
         self.traded_energy_current = {}
         self._populate_area_children_data(area_result_dict, core_stats, current_market_slot)
 

--- a/d3a_interface/sim_results/energy_trade_profile.py
+++ b/d3a_interface/sim_results/energy_trade_profile.py
@@ -18,7 +18,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 from typing import Dict, List
 from d3a_interface.constants_limits import FLOATING_POINT_TOLERANCE
 from d3a_interface.utils import round_floats_for_ui, add_or_create_key, key_in_dict_and_not_none, \
-    ui_str_to_pendulum_datetime
+    ui_str_to_pendulum_datetime, convert_pendulum_to_str_in_dict
 from d3a_interface.sim_results import area_name_from_area_or_iaa_name
 from d3a_interface.sim_results.results_abc import ResultsBaseClass
 
@@ -170,3 +170,16 @@ class EnergyTradeProfile(ResultsBaseClass):
                             market_trade[area_uuid][sold_bought][target_area][source_area]
                         )
         return global_trade
+
+    def restore_area_results_state(self, area_uuid, last_known_state_data):
+        pass
+
+    @property
+    def raw_results(self):
+        return convert_pendulum_to_str_in_dict(
+            self.traded_energy_profile, {}, ui_format=True)
+
+    @property
+    def ui_formatted_results(self):
+        return convert_pendulum_to_str_in_dict(
+            self.traded_energy_current, {}, ui_format=True)

--- a/d3a_interface/sim_results/energy_trade_profile.py
+++ b/d3a_interface/sim_results/energy_trade_profile.py
@@ -16,6 +16,7 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 from typing import Dict, List
+from copy import deepcopy
 from d3a_interface.constants_limits import FLOATING_POINT_TOLERANCE
 from d3a_interface.utils import round_floats_for_ui, add_or_create_key, key_in_dict_and_not_none, \
     ui_str_to_pendulum_datetime, convert_pendulum_to_str_in_dict, \
@@ -178,10 +179,11 @@ class EnergyTradeProfile(ResultsBaseClass):
 
     @property
     def plot_results(self):
-        return self.convert_timestamp_strings_to_datetimes(
-            convert_pendulum_to_str_in_dict(
-                self.traded_energy_profile, {}, ui_format=True)
+        traded_profile_for_plot = self.convert_timestamp_strings_to_datetimes(
+                deepcopy(self.traded_energy_profile)
         )
+        EnergyTradeProfile.add_sold_bought_lists(traded_profile_for_plot)
+        return traded_profile_for_plot
 
     @property
     def raw_results(self):

--- a/d3a_interface/sim_results/energy_trade_profile.py
+++ b/d3a_interface/sim_results/energy_trade_profile.py
@@ -176,7 +176,10 @@ class EnergyTradeProfile(ResultsBaseClass):
 
     @property
     def plot_results(self):
-        return self.convert_timestamp_strings_to_datetimes(self.traded_energy_profile)
+        return self.convert_timestamp_strings_to_datetimes(
+            convert_pendulum_to_str_in_dict(
+                self.traded_energy_profile, {}, ui_format=True)
+        )
 
     @property
     def raw_results(self):

--- a/d3a_interface/sim_results/energy_trade_profile.py
+++ b/d3a_interface/sim_results/energy_trade_profile.py
@@ -31,7 +31,7 @@ class EnergyTradeProfile(ResultsBaseClass):
         self.should_export_plots = should_export_plots
 
     def update(self, area_result_dict=None, core_stats=None, current_market_slot=None):
-        if not self._validate_update_parameters(
+        if not self._has_update_parameters(
                 area_result_dict, core_stats, current_market_slot):
             return
         current_market_slot = datetime_str_to_ui_formatted_datetime_str(current_market_slot)

--- a/d3a_interface/sim_results/energy_trade_profile.py
+++ b/d3a_interface/sim_results/energy_trade_profile.py
@@ -15,20 +15,24 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
+from typing import Dict, List
 from d3a_interface.constants_limits import FLOATING_POINT_TOLERANCE
 from d3a_interface.utils import round_floats_for_ui, add_or_create_key, key_in_dict_and_not_none, \
     ui_str_to_pendulum_datetime
 from d3a_interface.sim_results import area_name_from_area_or_iaa_name
-from d3a_interface.sim_results.aggregate_results import merge_energy_trade_profile_to_global
+from d3a_interface.sim_results.results_abc import ResultsBaseClass
 
 
-class EnergyTradeProfile:
+class EnergyTradeProfile(ResultsBaseClass):
     def __init__(self, should_export_plots):
         self.traded_energy_profile = {}
         self.traded_energy_current = {}
         self.should_export_plots = should_export_plots
 
     def update(self, area_result_dict=None, core_stats=None, current_market_slot=None):
+        if not self._validate_update_parameters(
+                area_result_dict, core_stats, current_market_slot):
+            return
         self.traded_energy_current = {}
         self._populate_area_children_data(area_result_dict, core_stats, current_market_slot)
 
@@ -66,7 +70,7 @@ class EnergyTradeProfile:
                 core_stats, current_market_slot)
 
             traded_energy_current_name = {area_name: self.traded_energy_current[area_name]}
-            self.traded_energy_profile = merge_energy_trade_profile_to_global(
+            self.traded_energy_profile = self.merge_results_to_global(
                 traded_energy_current_name, self.traded_energy_profile,
                 [current_market_slot])
 
@@ -145,3 +149,24 @@ class EnergyTradeProfile:
                             outdict[k][sold_bought][dev][target][datetime_obj] = \
                                 profile[k][sold_bought][dev][target][timestamp_str]
         return outdict
+
+    @staticmethod
+    def merge_results_to_global(market_trade: Dict, global_trade: Dict, slot_list: List):
+        if not global_trade:
+            global_trade = market_trade
+            return global_trade
+        for area_uuid in market_trade:
+            if area_uuid not in global_trade or global_trade[area_uuid] == {}:
+                global_trade[area_uuid] = {"sold_energy": {}, "bought_energy": {}}
+            for sold_bought in market_trade[area_uuid]:
+                for target_area in market_trade[area_uuid][sold_bought]:
+                    if target_area not in global_trade[area_uuid][sold_bought]:
+                        global_trade[area_uuid][sold_bought][target_area] = {}
+                    for source_area in market_trade[area_uuid][sold_bought][target_area]:
+                        if source_area not in global_trade[area_uuid][sold_bought][target_area]:
+                            global_trade[area_uuid][sold_bought][target_area][source_area] = \
+                                {i: 0 for i in slot_list}
+                        global_trade[area_uuid][sold_bought][target_area][source_area].update(
+                            market_trade[area_uuid][sold_bought][target_area][source_area]
+                        )
+        return global_trade

--- a/d3a_interface/sim_results/export_unmatched_loads.py
+++ b/d3a_interface/sim_results/export_unmatched_loads.py
@@ -54,8 +54,7 @@ class ExportUnmatchedLoads:
             if child['children']:
                 self.count_load_devices_in_setup(child)
 
-    def get_current_market_results(self, area_dict={}, core_stats={},
-                                   current_market_time_slot_str=None):
+    def get_current_market_results(self, area_dict, core_stats, current_market_time_slot_str):
         unmatched_loads = self.expand_to_ul_to_hours(
                 self.expand_ul_to_parents(
                     self.find_unmatched_loads(area_dict, core_stats, {},
@@ -237,6 +236,17 @@ class MarketUnmatchedLoads(ResultsBaseClass):
             global_ul = market_ul
             return global_ul
         return UnmatchedLoadsHelpers.accumulate_current_market_results(global_ul, market_ul)
+
+    def restore_area_results_state(self, area_uuid, last_known_state_data):
+        pass
+
+    @property
+    def raw_results(self):
+        return self.unmatched_loads
+
+    @property
+    def ui_formatted_results(self):
+        return self.last_unmatched_loads
 
 
 class UnmatchedLoadsHelpers:

--- a/d3a_interface/sim_results/export_unmatched_loads.py
+++ b/d3a_interface/sim_results/export_unmatched_loads.py
@@ -214,7 +214,7 @@ class MarketUnmatchedLoads(ResultsBaseClass):
         )
 
     def update(self, area_result_dict=None, core_stats=None, current_market_slot=None):
-        if not self._validate_update_parameters(
+        if not self._has_update_parameters(
                 area_result_dict, core_stats, current_market_slot):
             return
 

--- a/d3a_interface/sim_results/kpi.py
+++ b/d3a_interface/sim_results/kpi.py
@@ -213,7 +213,7 @@ class KPI(ResultsBaseClass):
                 }
 
     def update(self, area_dict, core_stats, current_market_slot):
-        if not self._validate_update_parameters(area_dict, core_stats, current_market_slot):
+        if not self._has_update_parameters(area_dict, core_stats, current_market_slot):
             return
         self.performance_indices[area_dict['name']] = \
             self.area_performance_indices(area_dict, core_stats)

--- a/d3a_interface/sim_results/kpi.py
+++ b/d3a_interface/sim_results/kpi.py
@@ -15,9 +15,11 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
+from typing import Dict
 from d3a_interface.utils import if_not_in_list_append
 from d3a_interface.sim_results import is_load_node_type, is_buffer_node_type, \
     is_prosumer_node_type, is_producer_node_type
+from d3a_interface.sim_results.results_abc import ResultsBaseClass
 
 
 class KPIState:
@@ -142,7 +144,7 @@ class KPIState:
         self._accumulate_energy_trace(core_stats)
 
 
-class KPI:
+class KPI(ResultsBaseClass):
     def __init__(self):
         self.performance_indices = dict()
         self.performance_indices_redis = dict()
@@ -210,8 +212,8 @@ class KPI:
                 "total_self_consumption_wh": area_kpis["total_self_consumption_wh"]
                 }
 
-    def update_kpis_from_area(self, area_dict, core_stats, current_market_time_slot_str):
-        if current_market_time_slot_str == "":
+    def update(self, area_dict, core_stats, current_market_slot):
+        if not self._validate_update_parameters(area_dict, core_stats, current_market_slot):
             return
         self.performance_indices[area_dict['name']] = \
             self.area_performance_indices(area_dict, core_stats)
@@ -220,7 +222,7 @@ class KPI:
 
         for child in area_dict['children']:
             if len(child['children']) > 0:
-                self.update_kpis_from_area(child, core_stats, current_market_time_slot_str)
+                self.update(child, core_stats, current_market_slot)
 
     def restore_area_results_state(self, area_dict, last_known_state_data):
         if area_dict['name'] not in self.state:
@@ -239,3 +241,15 @@ class KPI:
                 last_known_state_data['total_self_consumption_wh']
             self.state[area_dict['name']].self_consumption_buffer_wh = \
                 last_known_state_data['self_consumption_buffer_wh']
+
+    @staticmethod
+    def merge_results_to_global(market_device: Dict, global_device: Dict, *_):
+        raise NotImplemented("KPI endpoint supports only global results, merge not supported.")
+
+    @property
+    def raw_results(self):
+        return self.performance_indices
+
+    @property
+    def ui_formatted_results(self):
+        return self.performance_indices_redis

--- a/d3a_interface/sim_results/kpi.py
+++ b/d3a_interface/sim_results/kpi.py
@@ -244,7 +244,8 @@ class KPI(ResultsBaseClass):
 
     @staticmethod
     def merge_results_to_global(market_device: Dict, global_device: Dict, *_):
-        raise NotImplemented("KPI endpoint supports only global results, merge not supported.")
+        raise NotImplementedError(
+            "KPI endpoint supports only global results, merge not supported.")
 
     @property
     def raw_results(self):

--- a/d3a_interface/sim_results/market_price_energy_day.py
+++ b/d3a_interface/sim_results/market_price_energy_day.py
@@ -17,11 +17,14 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 from collections import OrderedDict
 from statistics import mean
+from typing import Dict
+from copy import deepcopy
 
 from d3a_interface.utils import key_in_dict_and_not_none, round_floats_for_ui
+from d3a_interface.sim_results.results_abc import ResultsBaseClass
 
 
-class MarketPriceEnergyDay:
+class MarketPriceEnergyDay(ResultsBaseClass):
     def __init__(self, should_export_plots):
         self._price_energy_day = {}
         self.csv_output = {}
@@ -55,7 +58,8 @@ class MarketPriceEnergyDay:
         price_lists[area_dict['uuid']][current_market_slot].extend(trade_rates)
 
     def update(self, area_result_dict=None, core_stats=None, current_market_slot=None):
-        if current_market_slot is None or area_result_dict is None or core_stats is None:
+        if not self._validate_update_parameters(
+                area_result_dict, core_stats, current_market_slot):
             return
         current_price_lists = self.gather_trade_rates(
             area_result_dict, core_stats, current_market_slot, {}
@@ -105,3 +109,16 @@ class MarketPriceEnergyDay:
                 if key_in_dict_and_not_none(area_core_stats, 'grid_fee_constant') else None
 
             redis_output[node_uuid]["price-energy-day"][0].update({"grid_fee_constant": fee})
+
+    @staticmethod
+    def merge_results_to_global(market_pe: Dict, global_pe: Dict, _):
+        if not global_pe:
+            global_pe = market_pe
+            return global_pe
+        for area_uuid in market_pe:
+            if area_uuid not in global_pe:
+                global_pe[area_uuid] = deepcopy(market_pe[area_uuid])
+            else:
+                global_pe[area_uuid]["price-energy-day"].extend(
+                    market_pe[area_uuid]["price-energy-day"])
+        return global_pe

--- a/d3a_interface/sim_results/market_price_energy_day.py
+++ b/d3a_interface/sim_results/market_price_energy_day.py
@@ -59,7 +59,7 @@ class MarketPriceEnergyDay(ResultsBaseClass):
         price_lists[area_dict['uuid']][current_market_slot].extend(trade_rates)
 
     def update(self, area_result_dict=None, core_stats=None, current_market_slot=None):
-        if not self._validate_update_parameters(
+        if not self._has_update_parameters(
                 area_result_dict, core_stats, current_market_slot):
             return
         current_price_lists = self.gather_trade_rates(

--- a/d3a_interface/sim_results/market_price_energy_day.py
+++ b/d3a_interface/sim_results/market_price_energy_day.py
@@ -111,7 +111,7 @@ class MarketPriceEnergyDay(ResultsBaseClass):
             redis_output[node_uuid]["price-energy-day"][0].update({"grid_fee_constant": fee})
 
     @staticmethod
-    def merge_results_to_global(market_pe: Dict, global_pe: Dict, _):
+    def merge_results_to_global(market_pe: Dict, global_pe: Dict, *_):
         if not global_pe:
             global_pe = market_pe
             return global_pe

--- a/d3a_interface/sim_results/market_price_energy_day.py
+++ b/d3a_interface/sim_results/market_price_energy_day.py
@@ -20,7 +20,8 @@ from statistics import mean
 from typing import Dict
 from copy import deepcopy
 
-from d3a_interface.utils import key_in_dict_and_not_none, round_floats_for_ui
+from d3a_interface.utils import key_in_dict_and_not_none, round_floats_for_ui, \
+    convert_pendulum_to_str_in_dict
 from d3a_interface.sim_results.results_abc import ResultsBaseClass
 
 
@@ -122,3 +123,14 @@ class MarketPriceEnergyDay(ResultsBaseClass):
                 global_pe[area_uuid]["price-energy-day"].extend(
                     market_pe[area_uuid]["price-energy-day"])
         return global_pe
+
+    def restore_area_results_state(self, area_uuid, last_known_state_data):
+        pass
+
+    @property
+    def raw_results(self):
+        return self.csv_output
+
+    @property
+    def ui_formatted_results(self):
+        return convert_pendulum_to_str_in_dict(self.redis_output, {})

--- a/d3a_interface/sim_results/results_abc.py
+++ b/d3a_interface/sim_results/results_abc.py
@@ -48,5 +48,6 @@ class ResultsBaseClass(ABC):
         """
         pass
 
+    @property
     def ui_formatted_results(self):
         return self.raw_results

--- a/d3a_interface/sim_results/results_abc.py
+++ b/d3a_interface/sim_results/results_abc.py
@@ -1,0 +1,35 @@
+from abc import ABC, abstractmethod
+from typing import Dict, List
+
+
+class ResultsBaseClass(ABC):
+
+    @staticmethod
+    def _validate_update_parameters(area_result_dict=None, core_stats=None,
+                                    current_market_slot=None):
+        """
+        Validates the update method parameters.
+        Should be used to early-return in case any one of the input parameters is empty.
+        If there are no results in this market slot, or if the market slot time is malformed
+        then the aggregated results should not be updated.
+        """
+        return not area_result_dict or not core_stats or not current_market_slot or \
+            current_market_slot == ""
+
+    @staticmethod
+    @abstractmethod
+    def merge_results_to_global(market_results: Dict, global_results: Dict, slot_list: List):
+        """
+        Merges a result set for one market to a global result set. Should be used when retrieving
+        individual market data from the DB, in order to merge the individual results with the
+        total requested results for a timeframe. slot_list is the list of the market slot times
+        that need to be accumulated, in case this is useful for the specific result class.
+        """
+        pass
+
+    @abstractmethod
+    def update(self, area_result_dict=None, core_stats=None, current_market_slot=None):
+        """
+        Updates the simulation results with bid/offer/trade data that arrive from the
+        """
+        pass

--- a/d3a_interface/sim_results/results_abc.py
+++ b/d3a_interface/sim_results/results_abc.py
@@ -5,7 +5,7 @@ from typing import Dict, List
 class ResultsBaseClass(ABC):
 
     @staticmethod
-    def _validate_update_parameters(area_result_dict, core_stats, current_market_slot):
+    def _has_update_parameters(area_result_dict, core_stats, current_market_slot):
         """
         Validates the update method parameters.
         Should be used to early-return in case any one of the input parameters is empty.

--- a/d3a_interface/sim_results/results_abc.py
+++ b/d3a_interface/sim_results/results_abc.py
@@ -5,16 +5,15 @@ from typing import Dict, List
 class ResultsBaseClass(ABC):
 
     @staticmethod
-    def _validate_update_parameters(area_result_dict=None, core_stats=None,
-                                    current_market_slot=None):
+    def _validate_update_parameters(area_result_dict, core_stats, current_market_slot):
         """
         Validates the update method parameters.
         Should be used to early-return in case any one of the input parameters is empty.
         If there are no results in this market slot, or if the market slot time is malformed
         then the aggregated results should not be updated.
         """
-        return not area_result_dict or not core_stats or not current_market_slot or \
-            current_market_slot == ""
+        return area_result_dict and core_stats and current_market_slot and \
+            current_market_slot != ""
 
     @staticmethod
     @abstractmethod

--- a/d3a_interface/sim_results/results_abc.py
+++ b/d3a_interface/sim_results/results_abc.py
@@ -27,8 +27,26 @@ class ResultsBaseClass(ABC):
         pass
 
     @abstractmethod
-    def update(self, area_result_dict=None, core_stats=None, current_market_slot=None):
+    def update(self, area_result_dict, core_stats, current_market_slot):
         """
         Updates the simulation results with bid/offer/trade data that arrive from the
         """
         pass
+
+    @abstractmethod
+    def restore_area_results_state(self, area_uuid, last_known_state_data):
+        """
+        Restores the state of the simulation results for a specific area, defined by area_uuid.
+        """
+        pass
+
+    @property
+    @abstractmethod
+    def raw_results(self):
+        """
+        Retrieves the accumulated result set.
+        """
+        pass
+
+    def ui_formatted_results(self):
+        return self.raw_results

--- a/d3a_interface/utils.py
+++ b/d3a_interface/utils.py
@@ -100,6 +100,10 @@ def str_to_pendulum_datetime(input_str):
     return pendulum_time
 
 
+def datetime_str_to_ui_formatted_datetime_str(input_str):
+    return format_datetime(str_to_pendulum_datetime(input_str), ui_format=True)
+
+
 def ui_str_to_pendulum_datetime(input_str):
     if input_str is None:
         return None


### PR DESCRIPTION
Potential improvement: currently the unit tests for the results classes are located either in d3a or in d3a-web, one more improvement to the process would be to port these to the d3a-interface, so that the code is tested in the same repo that it is created. 