### PR TITLE
D3ASIM-3307: Removed getsizeof call, which is unsupported from Pypy, …

### DIFF
--- a/d3a_interface/utils.py
+++ b/d3a_interface/utils.py
@@ -293,11 +293,11 @@ def deep_size_of(input_obj):
 
 
 def utf8len(s):
-    return len(s.encode('utf-8')) / 1000.0
+    return len(s.encode('utf-8'))
 
 
 def get_json_dict_memory_allocation_size(json_dict):
-    return sys.getsizeof(json.dumps(json_dict)) / 1024.
+    return utf8len(json.dumps(json_dict)) / 1024.
 
 
 def area_name_from_area_or_iaa_name(name):


### PR DESCRIPTION
…and estimated the memory utilization based on the length of the serialized string.