### PR TITLE
D3ASIM-3450: remove validation of area names

### DIFF
--- a/d3a_interface/area_validator.py
+++ b/d3a_interface/area_validator.py
@@ -19,9 +19,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 from d3a_interface.constants_limits import ConstSettings
 from d3a_interface.device_validator import validate_range_limit
 from d3a_interface.exceptions import D3AAreaException
-from d3a_interface.scenario_validators import validate_area_name
-from d3a_interface.utils import key_in_dict_and_not_none_and_greater_than_zero, \
-    key_in_dict_and_not_none_and_negative, key_in_dict_and_not_none
+from d3a_interface.utils import (
+    key_in_dict_and_not_none, key_in_dict_and_not_none_and_greater_than_zero,
+    key_in_dict_and_not_none_and_negative)
 
 
 GeneralSettings = ConstSettings.GeneralSettings
@@ -61,5 +61,3 @@ def validate_area(**kwargs):
     if key_in_dict_and_not_none_and_negative(kwargs, "export_capacity_kVA"):
         raise D3AAreaException({"misconfiguration": [f"export_capacity_kVA must be a "
                                                      f"positive value."]})
-    if key_in_dict_and_not_none(kwargs, 'name'):
-        validate_area_name({'name': kwargs['name']})

--- a/d3a_interface/constants_limits.py
+++ b/d3a_interface/constants_limits.py
@@ -17,9 +17,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 
 import sys
-from datetime import date, datetime
-from pendulum import duration, instance
 from collections import namedtuple
+from datetime import date, datetime
+
+from pendulum import duration, instance
 
 RangeLimit = namedtuple('RangeLimit', ('min', 'max'))
 RateRange = namedtuple('RateRange', ('initial', 'final'))
@@ -45,8 +46,6 @@ class ConstSettings:
         RUN_REAL_TIME = False
         # Boolean flag which forces d3a to dispatch events via redis channels
         EVENT_DISPATCHING_VIA_REDIS = False
-        # Restricted characters in area names
-        AREA_NAME_RESTRICTED_CHARS = ['/', '*']
         RATE_CHANGE_PER_UPDATE_LIMIT = RangeLimit(0, 1000)
         ENERGY_PROFILE_LIMIT = RangeLimit(0, sys.maxsize)
 

--- a/d3a_interface/scenario_validators.py
+++ b/d3a_interface/scenario_validators.py
@@ -18,18 +18,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from jsonschema.validators import validate
 
-from d3a_interface.constants_limits import ConstSettings
-from d3a_interface.exceptions import D3AAreaException
 from d3a_interface.schemas import ScenarioSchemas
 
 
 def scenario_validator(scenario_repr):
     validate(instance=scenario_repr, schema=ScenarioSchemas.scenario_schema)
-
-
-def validate_area_name(area_dict: dict):
-    area_name = area_dict.get('name', '')
-    intersect = set(area_name).intersection(
-        ConstSettings.GeneralSettings.AREA_NAME_RESTRICTED_CHARS)
-    if intersect:
-        raise D3AAreaException(f'Area name cannot have special characters {intersect}.')

--- a/tests/test_area_validator.py
+++ b/tests/test_area_validator.py
@@ -31,7 +31,6 @@ class TestValidateAreaSettings(unittest.TestCase):
                                         grid_fee_constant=0))
         self.assertIsNone(validate_area(grid_fee_percentage=0,
                                         grid_fee_constant=1))
-        self.assertIsNone(validate_area(name='my area'))
         with self.assertRaises(D3ADeviceException):
             validate_area(grid_fee_percentage=-1)
         with self.assertRaises(D3ADeviceException):
@@ -44,5 +43,3 @@ class TestValidateAreaSettings(unittest.TestCase):
             validate_area(import_capacity_kVA=-1.0)
         with self.assertRaises(D3AAreaException):
             validate_area(export_capacity_kVA=-1.0)
-        with self.assertRaises(D3AAreaException):
-            validate_area(name='my area /')

--- a/tests/test_scenario_validator.py
+++ b/tests/test_scenario_validator.py
@@ -16,13 +16,13 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 # flake8: noqa
-import unittest
-from parameterized import parameterized
 import json
-from jsonschema import ValidationError
+import unittest
 
-from d3a_interface.exceptions import D3AAreaException
-from d3a_interface.scenario_validators import scenario_validator, validate_area_name
+from jsonschema import ValidationError
+from parameterized import parameterized
+
+from d3a_interface.scenario_validators import scenario_validator
 
 
 class TestValidateGlobalSettings(unittest.TestCase):
@@ -73,8 +73,3 @@ class TestValidateGlobalSettings(unittest.TestCase):
                    '{"name": "battery_plant","type": "Storage", "batteryCapacity": 1.2, "initialCapacity": 0.6}, ' \
                    '{"name": "Load", "type": "Load", "avgPowerW": 200} ]}'
         self.assertRaises(ValidationError, scenario_validator, json.loads(scenario))
-        scenario = '{"name": "my area/", "numberOfClones": 10, "children": [' \
-                   '{"name": "battery", "type": "Storage", "batteryCapacity": 1.2, "initialCharge": 90}, ' \
-                   '{"name": "battery_plant","type": "Storage", "batteryCapacity": 1.2, "initialCapacity": 0.6}, ' \
-                   '{"name": "Load", "type": "Load", "avgPowerW": 200} ]}'
-        self.assertRaises(D3AAreaException, validate_area_name, json.loads(scenario))


### PR DESCRIPTION
The simulation results that can be downloaded by the users contain a directory structure based on the names of the areas in the scenario. If these names contain invalid characters (like `/`) the export process will either fail or be compromised.

Our previous solution was to restrict the allowed characters in area names. However, this created incompatibilities with several simulations that had already been created by users in the past. We therefore decided to allow those characters again, but to sanitize them when generating the paths for the downloaded results (see https://github.com/gridsingularity/d3a-web/pull/1326)