### PR TITLE
Refactor device validation tests using pytest

### DIFF
--- a/tests/test_device_validator.py
+++ b/tests/test_device_validator.py
@@ -15,9 +15,10 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
-import unittest
 from unittest.mock import patch
 from uuid import uuid4
+
+import pytest
 
 from d3a_interface.constants_limits import ConstSettings
 from d3a_interface.device_validator import (
@@ -32,262 +33,230 @@ PvSettings = ConstSettings.PVSettings
 StorageSettings = ConstSettings.StorageSettings
 
 
-class TestValidateDeviceSettings(unittest.TestCase):
+VALID_LOAD_PROFILE = {"1": 3, "10": 4.2, "22:00": 0.1}
 
-    def test_load_device_setting(self):
 
-        self.assertIsNone(validate_load_device(avg_power_W=100))
-        with self.assertRaises(D3ADeviceException):
-            validate_load_device(avg_power_W=-1)
-        with self.assertRaises(D3ADeviceException):
-            validate_load_device(avg_power_W=-1)
+class TestValidateDeviceSettings:
+    """Test the validation of the devices."""
 
-        self.assertIsNone(validate_load_device(hrs_per_day=0))
-        self.assertIsNone(validate_load_device(hrs_per_day=24))
-        with self.assertRaises(D3ADeviceException):
-            validate_load_device(hrs_per_day=25)
+    @staticmethod
+    @pytest.mark.parametrize("valid_arguments", [
+        {"avg_power_W": 100},
+        {"hrs_per_day": 0},
+        {"hrs_per_day": 24},
+        {"final_buying_rate": 0},
+        {"initial_buying_rate": 0},
+        {"initial_buying_rate": 5, "final_buying_rate": 10},
+        {"hrs_of_day": [0, 3, 20, 21, 22, 23, 24]},
+        {"hrs_of_day": [1, 2, 3, 5, 6, 10], "hrs_per_day": 6},
+        {"energy_rate_increase_per_update": 0},
+        {"fit_to_limit": False, "energy_rate_increase_per_update": 2},
+        {"daily_load_profile": VALID_LOAD_PROFILE}
+    ])
+    def test_load_device_setting_succeeds(valid_arguments):
+        """The PV device validation succeeds when valid arguments are provided."""
+        assert validate_load_device(**valid_arguments) is None
 
-        self.assertIsNone(validate_load_device(final_buying_rate=0))
-        with self.assertRaises(D3ADeviceException):
-            validate_load_device(final_buying_rate=-10)
+    @staticmethod
+    @pytest.mark.parametrize("failing_arguments", [
+        {"avg_power_W": -1},
+        {"hrs_per_day": 25},
+        {"final_buying_rate": -10},
+        {"initial_buying_rate": -2},
+        {"initial_buying_rate": 10, "final_buying_rate": 5},
+        {"hrs_of_day": [20, 21, 22, 23, 24, 25, 26]},
+        {"hrs_of_day": [1, 2, 3, 4, 5, 6], "hrs_per_day": 10},
+        {"energy_rate_increase_per_update": -1},
+        {"fit_to_limit": True, "energy_rate_increase_per_update": 2},
+        {"avg_power_W": 100, "daily_load_profile": VALID_LOAD_PROFILE},
+        {"hrs_per_day": 1, "daily_load_profile": VALID_LOAD_PROFILE},
+        {"hrs_of_day": [1, 2, 3, 4, 5, 6], "daily_load_profile": VALID_LOAD_PROFILE}
+    ])
+    def test_load_device_setting_fails(failing_arguments):
+        """The PV device validation fails when incompatible arguments are provided."""
+        with pytest.raises(D3ADeviceException):
+            validate_load_device(**failing_arguments)
 
-        self.assertIsNone(validate_load_device(initial_buying_rate=0))
-        with self.assertRaises(D3ADeviceException):
-            validate_load_device(initial_buying_rate=-2)
+    @staticmethod
+    @pytest.mark.parametrize("valid_arguments", [
+        {"panel_count": 1},
+        {"final_selling_rate": 0},
+        {"initial_selling_rate": 0},
+        {"initial_selling_rate": 11, "final_selling_rate": 10},
+        {"fit_to_limit": False, "energy_rate_decrease_per_update": 2},
+        {"energy_rate_decrease_per_update": 0},
+        {"max_panel_power_W": 0},
+        {"cloud_coverage": 4, "power_profile": ""}
+    ])
+    def test_pv_device_setting_succeeds(valid_arguments):
+        """The PV device validation succeeds when valid arguments are provided."""
+        assert validate_pv_device(**valid_arguments) is None
 
-        self.assertIsNone(validate_load_device(initial_buying_rate=5,
-                                               final_buying_rate=10))
-        with self.assertRaises(D3ADeviceException):
-            validate_load_device(initial_buying_rate=10, final_buying_rate=5)
+    @staticmethod
+    @pytest.mark.parametrize("failing_arguments", [
+        {"panel_count": -1},
+        {"final_selling_rate": -1},
+        {"initial_selling_rate": -20},
+        {"initial_selling_rate": 10, "final_selling_rate": 11},
+        {"fit_to_limit": True, "energy_rate_decrease_per_update": 2},
+        {"energy_rate_decrease_per_update": -1},
+        {"max_panel_power_W": -5},
+        {"cloud_coverage": 3, "power_profile": ""},
+        {"cloud_coverage": 2, "power_profile": ""}
+    ])
+    def test_pv_device_setting_fails(failing_arguments):
+        """The PV device validation fails when incompatible arguments are provided."""
+        with pytest.raises(D3ADeviceException):
+            validate_pv_device(**failing_arguments)
 
-        self.assertIsNone(validate_load_device(hrs_of_day=[0, 3, 20, 21, 22, 23, 24]))
-        with self.assertRaises(D3ADeviceException):
-            validate_load_device(hrs_of_day=[20, 21, 22, 23, 24, 25, 26])
+    @staticmethod
+    @pytest.mark.parametrize("valid_arguments", [
+        {"initial_soc": 10},
+        {"min_allowed_soc": 10},
+        {"initial_soc": 25, "min_allowed_soc": 20},
+        {"battery_capacity_kWh": 0.5},
+        {"max_abs_battery_power_kW": 0.05},
+        {"initial_selling_rate": 0.01},
+        {"final_selling_rate": 0.01},
+        {"initial_selling_rate": 11, "final_selling_rate": 10},
+        {"initial_buying_rate": 0.1},
+        {"final_buying_rate": 0.1},
+        {"initial_buying_rate": 10, "final_buying_rate": 11},
+        {"final_buying_rate": 14, "final_selling_rate": 15},
+        {"energy_rate_increase_per_update": 0.1},
+        {"energy_rate_decrease_per_update": 0.1},
+        {"fit_to_limit": False, "energy_rate_increase_per_update": 3},
+        {"fit_to_limit": False, "energy_rate_decrease_per_update": 3}
+    ])
+    def test_storage_device_setting_succeeds(valid_arguments):
+        """The storage device validation succeeds when correct arguments are provided."""
+        assert validate_storage_device(**valid_arguments) is None
 
-        self.assertIsNone(validate_load_device(hrs_of_day=[1, 2, 3, 5, 6, 10],
-                                               hrs_per_day=6))
-        with self.assertRaises(D3ADeviceException):
-            validate_load_device(hrs_of_day=[1, 2, 3, 4, 5, 6], hrs_per_day=10)
+    @staticmethod
+    @pytest.mark.parametrize("failing_arguments", [
+        {"initial_soc": -0.001},
+        {"min_allowed_soc": -0.001},
+        {"initial_soc": 15, "min_allowed_soc": 20},
+        {"battery_capacity_kWh": -1},
+        {"max_abs_battery_power_kW": -1},
+        {"initial_selling_rate": -1},
+        {"final_selling_rate": -2},
+        {"initial_selling_rate": 10, "final_selling_rate": 11},
+        {"initial_buying_rate": -2},
+        {"final_buying_rate": -3},
+        {"initial_buying_rate": 10, "final_buying_rate": 9},
+        {"final_buying_rate": 15, "final_selling_rate": 14},
+        {"energy_rate_increase_per_update": -5},
+        {"energy_rate_decrease_per_update": -3},
+        {"fit_to_limit": True, "energy_rate_increase_per_update": 3},
+        {"fit_to_limit": True, "energy_rate_decrease_per_update": 3}
+    ])
+    def test_storage_device_setting_fails(failing_arguments):
+        """The storage validation fails when incompatible arguments are provided."""
+        with pytest.raises(D3ADeviceException):
+            validate_storage_device(**failing_arguments)
 
-        self.assertIsNone(validate_load_device(energy_rate_increase_per_update=0))
-        with self.assertRaises(D3ADeviceException):
-            validate_load_device(energy_rate_increase_per_update=-1)
+    @staticmethod
+    def test_commercial_producer_setting():
+        """The commercial producer validation succeeds when correct arguments are provided."""
+        assert validate_commercial_producer(energy_rate=10) is None
 
-        self.assertIsNone(validate_load_device(fit_to_limit=False,
-                                               energy_rate_increase_per_update=2))
-        with self.assertRaises(D3ADeviceException):
-            validate_load_device(fit_to_limit=True,
-                                 energy_rate_increase_per_update=2)
-
-        valid_load_profile = {"1": 3, "10": 4.2, "22:00": 0.1}
-        with self.assertRaises(D3ADeviceException):
-            validate_load_device(avg_power_W=100,
-                                 daily_load_profile=valid_load_profile)
-
-        with self.assertRaises(D3ADeviceException):
-            validate_load_device(hrs_per_day=1,
-                                 daily_load_profile=valid_load_profile)
-
-        with self.assertRaises(D3ADeviceException):
-            validate_load_device(hrs_of_day=[1, 2, 3, 4, 5, 6],
-                                 daily_load_profile=valid_load_profile)
-
-        validate_load_device(daily_load_profile=valid_load_profile)
-
-    def test_pv_device_setting(self):
-        self.assertIsNone(validate_pv_device(panel_count=1))
-        with self.assertRaises(D3ADeviceException):
-            validate_pv_device(panel_count=-1)
-
-        self.assertIsNone(validate_pv_device(final_selling_rate=0))
-        with self.assertRaises(D3ADeviceException):
-            validate_pv_device(final_selling_rate=-1)
-
-        self.assertIsNone(validate_pv_device(initial_selling_rate=0))
-        with self.assertRaises(D3ADeviceException):
-            validate_pv_device(initial_selling_rate=-20)
-
-        self.assertIsNone(validate_pv_device(initial_selling_rate=11,
-                                             final_selling_rate=10))
-        with self.assertRaises(D3ADeviceException):
-            validate_pv_device(initial_selling_rate=10,
-                               final_selling_rate=11)
-
-        self.assertIsNone(validate_pv_device(fit_to_limit=False,
-                                             energy_rate_decrease_per_update=2))
-        with self.assertRaises(D3ADeviceException):
-            validate_pv_device(fit_to_limit=True,
-                               energy_rate_decrease_per_update=2)
-
-        self.assertIsNone(validate_pv_device(energy_rate_decrease_per_update=0))
-        with self.assertRaises(D3ADeviceException):
-            validate_pv_device(energy_rate_decrease_per_update=-1)
-
-        self.assertIsNone(validate_pv_device(max_panel_power_W=0))
-        with self.assertRaises(D3ADeviceException):
-            validate_pv_device(max_panel_power_W=-5)
-
-        self.assertIsNone(validate_pv_device(cloud_coverage=4, power_profile=""))
-        with self.assertRaises(D3ADeviceException):
-            validate_pv_device(cloud_coverage=3, power_profile="")
-        with self.assertRaises(D3ADeviceException):
-            validate_pv_device(cloud_coverage=2, power_profile="")
-
-    def test_storage_device_setting(self):
-        self.assertIsNone(validate_storage_device(initial_soc=10))
-        with self.assertRaises(D3ADeviceException):
-            validate_storage_device(initial_soc=-0.001)
-
-        self.assertIsNone(validate_storage_device(min_allowed_soc=10))
-        with self.assertRaises(D3ADeviceException):
-            validate_storage_device(min_allowed_soc=-0.001)
-
-        self.assertIsNone(validate_storage_device(initial_soc=25,
-                                                  min_allowed_soc=20))
-        with self.assertRaises(D3ADeviceException):
-            validate_storage_device(initial_soc=15, min_allowed_soc=20)
-
-        self.assertIsNone(validate_storage_device(battery_capacity_kWh=0.5))
-        with self.assertRaises(D3ADeviceException):
-            validate_storage_device(battery_capacity_kWh=-1)
-
-        self.assertIsNone(validate_storage_device(max_abs_battery_power_kW=0.05))
-        with self.assertRaises(D3ADeviceException):
-            validate_storage_device(max_abs_battery_power_kW=-1)
-
-        self.assertIsNone(validate_storage_device(initial_selling_rate=0.01))
-        with self.assertRaises(D3ADeviceException):
-            validate_storage_device(initial_selling_rate=-1)
-
-        self.assertIsNone(validate_storage_device(final_selling_rate=0.01))
-        with self.assertRaises(D3ADeviceException):
-            validate_storage_device(final_selling_rate=-2)
-
-        self.assertIsNone(validate_storage_device(initial_selling_rate=11,
-                                                  final_selling_rate=10))
-        with self.assertRaises(D3ADeviceException):
-            validate_storage_device(initial_selling_rate=10,
-                                    final_selling_rate=11)
-
-        self.assertIsNone(validate_storage_device(initial_buying_rate=0.1))
-        with self.assertRaises(D3ADeviceException):
-            validate_storage_device(initial_buying_rate=-2)
-
-        self.assertIsNone(validate_storage_device(final_buying_rate=0.1))
-        with self.assertRaises(D3ADeviceException):
-            validate_storage_device(final_buying_rate=-3)
-
-        self.assertIsNone(validate_storage_device(initial_buying_rate=10,
-                                                  final_buying_rate=11))
-        with self.assertRaises(D3ADeviceException):
-            validate_storage_device(initial_buying_rate=10,
-                                    final_buying_rate=9)
-
-        self.assertIsNone(validate_storage_device(final_buying_rate=14,
-                                                  final_selling_rate=15))
-        with self.assertRaises(D3ADeviceException):
-            validate_storage_device(final_buying_rate=15,
-                                    final_selling_rate=14)
-
-        self.assertIsNone(validate_storage_device(energy_rate_increase_per_update=0.1))
-        with self.assertRaises(D3ADeviceException):
-            validate_storage_device(energy_rate_increase_per_update=-5)
-
-        self.assertIsNone(validate_storage_device(energy_rate_decrease_per_update=0.1))
-        with self.assertRaises(D3ADeviceException):
-            validate_storage_device(energy_rate_decrease_per_update=-3)
-
-        self.assertIsNone(validate_storage_device(fit_to_limit=False,
-                                                  energy_rate_increase_per_update=3))
-        self.assertIsNone(validate_storage_device(fit_to_limit=False,
-                                                  energy_rate_decrease_per_update=3))
-        with self.assertRaises(D3ADeviceException):
-            validate_storage_device(fit_to_limit=True,
-                                    energy_rate_increase_per_update=3)
-        with self.assertRaises(D3ADeviceException):
-            validate_storage_device(fit_to_limit=True,
-                                    energy_rate_decrease_per_update=3)
-
-    def test_commercial_producer_setting(self):
-        self.assertIsNone(validate_commercial_producer(energy_rate=10))
-        with self.assertRaises(D3ADeviceException):
+    @staticmethod
+    def test_commercial_producer_setting_fails():
+        """The commercial producer validation fails when incompatible arguments are provided."""
+        with pytest.raises(D3ADeviceException):
             validate_commercial_producer(energy_rate=-5)
 
-    def test_market_maker_setting(self):
-        self.assertIsNone(
-            validate_market_maker(energy_rate_profile=str({"0": "30", "2": "33"}),
-                                  energy_rate_profile_uuid=str(uuid4())))
-        self.assertIsNone(
-            validate_market_maker(energy_rate_profile=str({"0": "30", "2": "33"}),
-                                  energy_rate_profile_uuid=str(uuid4()),
-                                  grid_connected=True))
-        self.assertIsNone(
-            validate_market_maker(energy_rate=str({"0": 30, "2": 33})))
-        self.assertIsNone(validate_market_maker(energy_rate=35))
-        with self.assertRaises(D3ADeviceException):
-            validate_market_maker(energy_rate_profile=30)
-        with self.assertRaises(D3ADeviceException):
-            validate_market_maker(energy_rate=-5)
-        with self.assertRaises(D3ADeviceException):
-            validate_market_maker(energy_rate_profile=str({"0": 30, "2": 33}))
-        with self.assertRaises(D3ADeviceException):
-            validate_market_maker(energy_rate=str({"0": -30, "2": 33}))
-        with self.assertRaises(D3ADeviceException):
-            validate_market_maker(grid_connected=30)
+    @staticmethod
+    @pytest.mark.parametrize("valid_arguments", [
+        {"energy_rate_profile": str({"0": "30", "2": "33"}),
+         "energy_rate_profile_uuid": str(uuid4())},
+        {"energy_rate_profile": str({"0": "30", "2": "33"}),
+         "energy_rate_profile_uuid": str(uuid4()), "grid_connected": True},
+        {"energy_rate": str({"0": 30, "2": 33})},
+        {"energy_rate": 35}
+    ])
+    def test_market_maker_setting_succeeds(valid_arguments):
+        """The market maker validation succeeds when correct arguments are provided."""
+        assert validate_market_maker(**valid_arguments) is None
 
-    def test_infinite_bus_setting(self):
-        self.assertIsNone(
-            validate_infinite_bus(energy_rate_profile=str({"0": "30", "2": "33"}),
-                                  energy_rate_profile_uuid=str(uuid4())))
-        self.assertIsNone(
-            validate_infinite_bus(energy_rate_profile=str({"0": "30", "2": "33"}),
-                                  energy_rate_profile_uuid=str(uuid4()),
-                                  buying_rate_profile=str({"0": "29", "2": "28"}),
-                                  buying_rate_profile_uuid=str(uuid4())))
-        self.assertIsNone(
-            validate_infinite_bus(energy_rate=str({"0": 30, "2": 33})))
-        self.assertIsNone(validate_infinite_bus(energy_rate=35))
-        with self.assertRaises(D3ADeviceException):
-            validate_infinite_bus(energy_rate_profile=30)
-        with self.assertRaises(D3ADeviceException):
-            validate_infinite_bus(energy_rate=-5)
-        with self.assertRaises(D3ADeviceException):
-            validate_infinite_bus(energy_rate_profile=str({"0": 30, "2": 33}))
-        with self.assertRaises(D3ADeviceException):
-            validate_infinite_bus(energy_rate=str({"0": -30, "2": 33}))
-        with self.assertRaises(D3ADeviceException):
-            validate_infinite_bus(buying_rate_profile=str({"0": "29", "2": "28"}))
-        with self.assertRaises(D3ADeviceException):
-            validate_infinite_bus(buying_rate_profile_uuid=uuid4())
+    @staticmethod
+    @pytest.mark.parametrize("failing_arguments", [
+        {"energy_rate_profile": 30},
+        {"energy_rate": -5},
+        {"energy_rate_profile": str({"0": 30, "2": 33})},
+        {"energy_rate": str({"0": -30, "2": 33})},
+        {"grid_connected": 30}
+    ])
+    def test_market_maker_setting_fails(failing_arguments):
+        """The market maker validation fails when incompatible arguments are provided."""
+        with pytest.raises(D3ADeviceException):
+            validate_market_maker(**failing_arguments)
 
-    def test_finite_diesel_generator(self):
-        self.assertIsNone(validate_finite_diesel_generator(max_available_power_kW=1))
-        with self.assertRaises(D3ADeviceException):
-            validate_finite_diesel_generator(max_available_power_kW=-1)
-        self.assertIsNone(validate_finite_diesel_generator(energy_rate=1))
-        self.assertIsNone(validate_finite_diesel_generator(energy_rate=100))
-        with self.assertRaises(D3ADeviceException):
-            validate_finite_diesel_generator(energy_rate=-1)
+    @staticmethod
+    @pytest.mark.parametrize("valid_arguments", [
+        {"energy_rate_profile": str({"0": "30", "2": "33"}),
+         "energy_rate_profile_uuid": str(uuid4())},
+        {"energy_rate_profile": str({"0": "30", "2": "33"}),
+         "energy_rate_profile_uuid": str(uuid4()),
+         "buying_rate_profile": str({"0": "29", "2": "28"}),
+         "buying_rate_profile_uuid": str(uuid4())},
+        {"energy_rate": str({"0": 30, "2": 33})},
+        {"energy_rate": 35}
+    ])
+    def test_infinite_bus_setting_succeeds(valid_arguments):
+        """The infinite bus validation succeeds when correct arguments are provided."""
+        assert validate_infinite_bus(**valid_arguments) is None
+
+    @staticmethod
+    @pytest.mark.parametrize("failing_arguments", [
+        {"energy_rate_profile": 30},
+        {"energy_rate": -5},
+        {"energy_rate_profile": str({"0": 30, "2": 33})},
+        {"energy_rate": str({"0": -30, "2": 33})},
+        {"buying_rate_profile": str({"0": "29", "2": "28"})},
+        {"buying_rate_profile_uuid": uuid4()}
+    ])
+    def test_infinite_bus_setting_fails(failing_arguments):
+        """The infinite bus validation fails when incompatible arguments are provided."""
+        with pytest.raises(D3ADeviceException):
+            validate_infinite_bus(**failing_arguments)
+
+    @staticmethod
+    @pytest.mark.parametrize("valid_arguments", [
+        {"max_available_power_kW": 1},
+        {"energy_rate": 1},
+        {"energy_rate": 100}
+    ])
+    def test_finite_diesel_generator_succeeds(valid_arguments):
+        """The FiniteDiesel validation succeeds when correct arguments are provided."""
+        assert validate_finite_diesel_generator(**valid_arguments) is None
+
+    @staticmethod
+    @pytest.mark.parametrize("failing_arguments", [
+        {"max_available_power_kW": -1},
+        {"energy_rate": -1}])
+    def test_finite_diesel_generator_fails(failing_arguments):
+        """The FiniteDiesel validation fails when incompatible arguments are provided."""
+        with pytest.raises(D3ADeviceException):
+            validate_finite_diesel_generator(**failing_arguments)
 
 
-class TestHomeMeterValidator(unittest.TestCase):
+class TestHomeMeterValidator:
     """Tests for the HomeMeterValidator class."""
 
-    @classmethod
-    def setUpClass(cls) -> None:
-        """Set up requirements for all individual tests."""
-        cls.validator = HomeMeterValidator
-
+    @staticmethod
     @patch.object(HomeMeterValidator, "validate_rate")
     @patch.object(HomeMeterValidator, "validate_energy")
-    def test_validate(self, validate_energy_mock, validate_price_mock):
+    def test_validate(validate_energy_mock, validate_price_mock):
         """The validate method correctly calls the individual validation methods."""
-        self.validator.validate()
+        HomeMeterValidator.validate()
         validate_price_mock.assert_called_once_with()
         validate_energy_mock.assert_called_once_with()
 
+    @staticmethod
     @patch("d3a_interface.device_validator.validate_range_limit")
-    def test_validate_price_executes(self, validate_range_limit_mock):
+    def test_validate_price_executes(validate_range_limit_mock):
         """The validation is executed when suitable arguments are provided.
 
         Note: this does not necessarily mean that the validation is successful, as it also depends
@@ -299,18 +268,17 @@ class TestHomeMeterValidator(unittest.TestCase):
             "initial_selling_rate": 13, "final_selling_rate": 10,
             "energy_rate_decrease_per_update": 2
         }
-        self.validator.validate_rate(**arguments)
+        HomeMeterValidator.validate_rate(**arguments)
         assert validate_range_limit_mock.call_count == 6
 
-    def test_validate_price_fails(self):
+    @staticmethod
+    @pytest.mark.parametrize("failing_arguments", [
+        {"initial_buying_rate": 15, "final_buying_rate": 13},
+        {"energy_rate_increase_per_update": 1, "fit_to_limit": True},
+        {"initial_selling_rate": 10, "final_selling_rate": 13},
+        {"energy_rate_decrease_per_update": 1, "fit_to_limit": True}
+    ])
+    def test_validate_price_fails(failing_arguments):
         """The validation fails when incompatible arguments are provided."""
-        failing_arguments = [
-            {"initial_buying_rate": 15, "final_buying_rate": 13},
-            {"energy_rate_increase_per_update": 1, "fit_to_limit": True},
-            {"initial_selling_rate": 10, "final_selling_rate": 13},
-            {"energy_rate_decrease_per_update": 1, "fit_to_limit": True}
-        ]
-        for arguments in failing_arguments:
-            with self.subTest(arguments=arguments):
-                with self.assertRaises(D3ADeviceException):
-                    self.validator.validate_rate(**arguments)
+        with pytest.raises(D3ADeviceException):
+            HomeMeterValidator.validate_rate(**failing_arguments)


### PR DESCRIPTION
- `unittest.subTest` can't be used with `pytest`, unless additional packages are employed (see [pytest docs](https://docs.pytest.org/en/6.2.x/unittest.html?highlight=subtest));
- `@pytest.mark.parametrize` and fixtures can't be used if the test class inherits from `unittest.TestCase`.

For these reasons, this PR refactors the unit tests for device validation to make a broader use of pytest, its assertions and its parametrized parameters.