### PR TITLE
Fix PAC multi markets matching

### DIFF
--- a/d3a_interface/matching_algorithms/pay_as_clear_matching_algorithm.py
+++ b/d3a_interface/matching_algorithms/pay_as_clear_matching_algorithm.py
@@ -48,6 +48,7 @@ class PayAsClearMatchingAlgorithm(BaseMatchingAlgorithm):
         self.sorted_offers = []
 
     def get_matches_recommendations(self, matching_data):
+        matches = []
         for market_id, data in matching_data.items():
             bids = data.get("bids")
             offers = data.get("offers")
@@ -60,10 +61,9 @@ class PayAsClearMatchingAlgorithm(BaseMatchingAlgorithm):
             if clearing_energy > 0:
                 log.info(f"Market Clearing Rate: {clearing_rate} "
                          f"||| Clearing Energy: {clearing_energy} ")
-            matches = self._create_bid_offer_matches(
-                clearing, self.sorted_offers, self.sorted_bids, market_id
-                )
-            return matches
+            matches.extend(self._create_bid_offer_matches(
+                clearing, self.sorted_offers, self.sorted_bids, market_id))
+        return matches
 
     @staticmethod
     def _discrete_point_curve(obj_list, round_functor):

--- a/tests/test_matching_algorithms/test_pay_as_clear_matching_algorithm.py
+++ b/tests/test_matching_algorithms/test_pay_as_clear_matching_algorithm.py
@@ -242,5 +242,18 @@ class TestPayAsClearMatchingAlgorithm:
         expected_trades = [{"market_id": "market1",
                             "bids": [{"id": 3, "buyer": "C", "energy_rate": 3, "energy": 20}],
                             "offers": [{"id": 4, "seller": "A", "energy_rate": 1.00001,
-                                        "energy": 25}], "selected_energy": 20, "trade_rate": 3}]
+                                        "energy": 25}], "selected_energy": 20, "trade_rate": 3},
+                           {"market_id": "market2",
+                            "bids": [{"id": 9, "buyer": "C", "energy_rate": 6, "energy": 50}],
+                            "offers": [{"id": 10, "seller": "A", "energy_rate": 1,
+                                        "energy": 55}], "selected_energy": 50, "trade_rate": 2},
+                           {"market_id": "market2",
+                            "bids": [{"id": 8, "buyer": "B", "energy_rate": 2, "energy": 45}],
+                            "offers": [{"id": 10, "seller": "A", "energy_rate": 1, "energy": 55}],
+                            "selected_energy": 5, "trade_rate": 2},
+                           {"market_id": "market2",
+                            "bids": [{"id": 8, "buyer": "B", "energy_rate": 2, "energy": 45}],
+                            "offers": [{"id": 12, "seller": "C", "energy_rate": 1,
+                                        "energy": 65}], "selected_energy": 40, "trade_rate": 2},
+                           ]
         assert trades == expected_trades


### PR DESCRIPTION
Fix a bug when sending multiple markets keys to the matcher
There is a test that should've checked this but there was a wrong expected data values