### PR TITLE
Refactoring: rename home meter to smart meter

### DIFF
--- a/d3a_interface/constants_limits.py
+++ b/d3a_interface/constants_limits.py
@@ -128,7 +128,7 @@ class ConstSettings:
         MAX_PANEL_OUTPUT_W = 160
         PV_PENALTY_RATE = 0
 
-    class HomeMeterSettings:
+    class SmartMeterSettings:
         # Production constants
         SELLING_RATE_RANGE = RateRange(30, 0)
         INITIAL_SELLING_RATE_LIMIT = RangeLimit(0, 10000)

--- a/d3a_interface/schemas.py
+++ b/d3a_interface/schemas.py
@@ -42,7 +42,7 @@ class ScenarioSchemas:
                                         {"$ref": "#/definitions/area"},
                                         {"$ref": "#/definitions/pv"},
                                         {"$ref": "#/definitions/load"},
-                                        {"$ref": "#/definitions/home_meter"},
+                                        {"$ref": "#/definitions/smart_meter"},
                                         {"$ref": "#/definitions/infinite_power_plant"},
                                         {"$ref": "#/definitions/finite_power_plant"},
                                         {"$ref": "#/definitions/storage"}
@@ -125,11 +125,11 @@ class ScenarioSchemas:
                                                      {"type": "string"}]}
                 }
             },
-            "home_meter": {
+            "smart_meter": {
                 "type": "object",
                 "properties": {
                     "name": {"type": "string"},
-                    "type": {"enum": ["HomeMeter"]},
+                    "type": {"enum": ["SmartMeter"]},
                     "number_of_clones": {"type": "number"},
                     "uuid": {"type": "string"},
                     "libraryUUID": {"anyOf": [{"type": "string"}, {"type": "null"}]},
@@ -174,7 +174,7 @@ class ScenarioSchemas:
             {"$ref": "#/definitions/area"},
             {"$ref": "#/definitions/pv"},
             {"$ref": "#/definitions/load"},
-            {"$ref": "#/definitions/home_meter"},
+            {"$ref": "#/definitions/smart_meter"},
             {"$ref": "#/definitions/infinite_power_plant"},
             {"$ref": "#/definitions/finite_power_plant"},
             {"$ref": "#/definitions/storage"}

--- a/d3a_interface/sim_results/device_statistics.py
+++ b/d3a_interface/sim_results/device_statistics.py
@@ -144,8 +144,8 @@ class DeviceStatistics(ResultsBaseClass):
             return "soc_history_%"
         if is_load_node_type(area):
             return "load_profile_kWh"
-        if area["type"] == "HomeMeterStrategy":
-            return "home_meter_profile_kWh"
+        if area["type"] == "SmartMeterStrategy":
+            return "smart_meter_profile_kWh"
         if area["type"] == "FinitePowerPlant":
             return "production_kWh"
 

--- a/d3a_interface/validators/__init__.py
+++ b/d3a_interface/validators/__init__.py
@@ -17,7 +17,7 @@ not, see <http://www.gnu.org/licenses/>.
 __all__ = [
     "CommercialProducerValidator",
     "FiniteDieselGeneratorValidator",
-    "HomeMeterValidator",
+    "SmartMeterValidator",
     "InfiniteBusValidator",
     "LoadValidator",
     "MarketMakerValidator",
@@ -27,7 +27,7 @@ __all__ = [
 from d3a_interface.validators.cep_validator import CommercialProducerValidator
 from d3a_interface.validators.finite_diesel_generator_validator import (
     FiniteDieselGeneratorValidator)
-from d3a_interface.validators.home_meter_validator import HomeMeterValidator
+from d3a_interface.validators.smart_meter_validator import SmartMeterValidator
 from d3a_interface.validators.infinite_bus_validator import InfiniteBusValidator
 from d3a_interface.validators.load_validator import LoadValidator
 from d3a_interface.validators.market_maker_validator import MarketMakerValidator

--- a/d3a_interface/validators/smart_meter_validator.py
+++ b/d3a_interface/validators/smart_meter_validator.py
@@ -19,11 +19,11 @@ from d3a_interface.validators import utils
 from d3a_interface.validators.base_validator import BaseValidator
 
 GeneralSettings = ConstSettings.GeneralSettings
-HomeMeterSettings = ConstSettings.HomeMeterSettings
+SmartMeterSettings = ConstSettings.SmartMeterSettings
 
 
-class HomeMeterValidator(BaseValidator):
-    """Validator class for Home Meter devices."""
+class SmartMeterValidator(BaseValidator):
+    """Validator class for Smart Meter devices."""
 
     @classmethod
     def validate(cls, **kwargs):
@@ -32,40 +32,40 @@ class HomeMeterValidator(BaseValidator):
 
     @classmethod
     def validate_rate(cls, **kwargs):
-        """Validate rates of a Home Meter device."""
+        """Validate rates of a Smart Meter device."""
         utils.validate_fit_to_limit(
             fit_to_limit=kwargs.get("fit_to_limit"),
             energy_rate_increase_per_update=kwargs.get("energy_rate_increase_per_update"),
             energy_rate_decrease_per_update=kwargs.get("energy_rate_decrease_per_update"))
-        cls._validate_home_meter_consumption_rates(**kwargs)
-        cls._validate_home_meter_production_rates(**kwargs)
+        cls._validate_smart_meter_consumption_rates(**kwargs)
+        cls._validate_smart_meter_production_rates(**kwargs)
 
     @staticmethod
-    def _validate_home_meter_consumption_rates(**kwargs):
+    def _validate_smart_meter_consumption_rates(**kwargs):
         """Validate rates related to the consumption activity of the device."""
         if kwargs.get("final_buying_rate") is not None:
             error_message = {
                 "misconfiguration": [
                     "final_buying_rate should be in between "
-                    f"{HomeMeterSettings.FINAL_BUYING_RATE_LIMIT.min} & "
-                    f"{HomeMeterSettings.FINAL_BUYING_RATE_LIMIT.max}."]}
+                    f"{SmartMeterSettings.FINAL_BUYING_RATE_LIMIT.min} & "
+                    f"{SmartMeterSettings.FINAL_BUYING_RATE_LIMIT.max}."]}
 
             utils.validate_range_limit(
-                HomeMeterSettings.FINAL_BUYING_RATE_LIMIT.min,
+                SmartMeterSettings.FINAL_BUYING_RATE_LIMIT.min,
                 kwargs["final_buying_rate"],
-                HomeMeterSettings.FINAL_BUYING_RATE_LIMIT.max, error_message)
+                SmartMeterSettings.FINAL_BUYING_RATE_LIMIT.max, error_message)
 
         if kwargs.get("initial_buying_rate") is not None:
             error_message = {
                 "misconfiguration": [
                     "initial_buying_rate should be in between "
-                    f"{HomeMeterSettings.INITIAL_BUYING_RATE_LIMIT.min} & "
-                    f"{HomeMeterSettings.INITIAL_BUYING_RATE_LIMIT.max}"]}
+                    f"{SmartMeterSettings.INITIAL_BUYING_RATE_LIMIT.min} & "
+                    f"{SmartMeterSettings.INITIAL_BUYING_RATE_LIMIT.max}"]}
 
             utils.validate_range_limit(
-                HomeMeterSettings.INITIAL_BUYING_RATE_LIMIT.min,
+                SmartMeterSettings.INITIAL_BUYING_RATE_LIMIT.min,
                 kwargs["initial_buying_rate"],
-                HomeMeterSettings.INITIAL_BUYING_RATE_LIMIT.max, error_message)
+                SmartMeterSettings.INITIAL_BUYING_RATE_LIMIT.max, error_message)
 
         if (kwargs.get("initial_buying_rate") is not None
                 and kwargs.get("final_buying_rate") is not None
@@ -89,31 +89,31 @@ class HomeMeterValidator(BaseValidator):
                 GeneralSettings.RATE_CHANGE_PER_UPDATE_LIMIT.max, error_message)
 
     @staticmethod
-    def _validate_home_meter_production_rates(**kwargs):
+    def _validate_smart_meter_production_rates(**kwargs):
         """Validate rates related to the production activity of the device."""
         if kwargs.get("final_selling_rate") is not None:
             error_message = {
                 "misconfiguration": [
                     "final_selling_rate should be in between "
-                    f"{HomeMeterSettings.FINAL_SELLING_RATE_LIMIT.min} & "
-                    f"{HomeMeterSettings.FINAL_SELLING_RATE_LIMIT.max}"]}
+                    f"{SmartMeterSettings.FINAL_SELLING_RATE_LIMIT.min} & "
+                    f"{SmartMeterSettings.FINAL_SELLING_RATE_LIMIT.max}"]}
 
             utils.validate_range_limit(
-                HomeMeterSettings.FINAL_SELLING_RATE_LIMIT.min,
+                SmartMeterSettings.FINAL_SELLING_RATE_LIMIT.min,
                 kwargs["final_selling_rate"],
-                HomeMeterSettings.FINAL_SELLING_RATE_LIMIT.max, error_message)
+                SmartMeterSettings.FINAL_SELLING_RATE_LIMIT.max, error_message)
 
         if kwargs.get("initial_selling_rate") is not None:
             error_message = {
                 "misconfiguration": [
                     "initial_selling_rate should be in between "
-                    f"{HomeMeterSettings.INITIAL_SELLING_RATE_LIMIT.min} & "
-                    f"{HomeMeterSettings.INITIAL_SELLING_RATE_LIMIT.max}"]}
+                    f"{SmartMeterSettings.INITIAL_SELLING_RATE_LIMIT.min} & "
+                    f"{SmartMeterSettings.INITIAL_SELLING_RATE_LIMIT.max}"]}
 
             utils.validate_range_limit(
-                HomeMeterSettings.INITIAL_SELLING_RATE_LIMIT.min,
+                SmartMeterSettings.INITIAL_SELLING_RATE_LIMIT.min,
                 kwargs["initial_selling_rate"],
-                HomeMeterSettings.INITIAL_SELLING_RATE_LIMIT.max, error_message)
+                SmartMeterSettings.INITIAL_SELLING_RATE_LIMIT.max, error_message)
 
         if (kwargs.get("initial_selling_rate") is not None
                 and kwargs.get("final_selling_rate") is not None

--- a/tests/test_device_validator.py
+++ b/tests/test_device_validator.py
@@ -23,7 +23,7 @@ import pytest
 from d3a_interface.constants_limits import ConstSettings
 from d3a_interface.exceptions import D3ADeviceException
 from d3a_interface.validators import (
-    HomeMeterValidator, LoadValidator, PVValidator, StorageValidator, CommercialProducerValidator,
+    SmartMeterValidator, LoadValidator, PVValidator, StorageValidator, CommercialProducerValidator,
     InfiniteBusValidator, MarketMakerValidator, FiniteDieselGeneratorValidator)
 
 GeneralSettings = ConstSettings.GeneralSettings
@@ -255,14 +255,14 @@ class TestValidateDeviceSettings:
             FiniteDieselGeneratorValidator.validate(**failing_arguments)
 
 
-class TestHomeMeterValidator:
-    """Tests for the HomeMeterValidator class."""
+class TestSmartMeterValidator:
+    """Tests for the SmartMeterValidator class."""
 
     @staticmethod
-    @patch.object(HomeMeterValidator, "validate_rate")
+    @patch.object(SmartMeterValidator, "validate_rate")
     def test_validate(validate_price_mock):
         """The validate method correctly calls the individual validation methods."""
-        HomeMeterValidator.validate()
+        SmartMeterValidator.validate()
         validate_price_mock.assert_called_once_with()
 
     @staticmethod
@@ -277,7 +277,7 @@ class TestHomeMeterValidator:
     ])
     def test_validate_price_succeeds(valid_arguments):
         """The validation succeeds when valid arguments are provided."""
-        assert HomeMeterValidator.validate(**valid_arguments) is None
+        assert SmartMeterValidator.validate(**valid_arguments) is None
 
     @staticmethod
     @pytest.mark.parametrize("failing_arguments", [
@@ -291,4 +291,4 @@ class TestHomeMeterValidator:
     def test_validate_price_fails(failing_arguments):
         """The validation fails when incompatible arguments are provided."""
         with pytest.raises(D3ADeviceException):
-            HomeMeterValidator.validate_rate(**failing_arguments)
+            SmartMeterValidator.validate_rate(**failing_arguments)


### PR DESCRIPTION
This refactoring was asked by the stakeholders to homogenize our terminology to the energy market's.